### PR TITLE
style cleanup and add as_bytes func

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "ord-uuid"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "rand",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "ord-uuid"
 repository = "https://github.com/josephcopenhaver/ord-uuid-rs"
 description = "Creates lexically sortable uuid values of size 16 bytes."
 license = "MIT"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Simplifies a small part of compliance with the original RFC 4122 spec to be less invasive.