### PR TITLE
adding ordering traits and fixing some comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "ord-uuid"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "rand",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "ord-uuid"
 repository = "https://github.com/josephcopenhaver/ord-uuid-rs"
 description = "Creates lexically sortable uuid values of size 16 bytes."
 license = "MIT"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,12 +258,12 @@ fn order_bits_lexically_for_ord_v(v: u128, version_bits: OrdVersionBits) -> u128
     (v & (0xFFFFFFFFFFFF << 80))
     // 0xFFFFFFFFFFFF00000000
     //
-    // move time low nibs
+    // move after version - before variant bits
     // 0x0000000000000FFF0000
     | ((v & (0xFFF << 64)) << 4)
     // 0xFFFFFFFFFFFFFFF00000
     //
-    // move clock seq nibs and node bits
+    // move after variant bits (including node bits)
     // 0x00000000000000003FFF
     | ((v & 0x3FFF_FFFFFFFFFFFF) << 6)
     //


### PR DESCRIPTION
It's a no brainer to start satisfying these traits.

Copy is intentionally not implemented because who knows, maybe in the future heap allocated types might be supported and pooled in some fashion.