### PR TITLE
minor readability changes and update of uuid deps

### DIFF
--- a/.github/workflows/test-lib.yml
+++ b/.github/workflows/test-lib.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "35 11 * * 0" # INIT_CRON_EXPRESSION: echo "$(((RANDOM%60))) $(((RANDOM%24)))"' * * '"$( if [[ $(((RANDOM%2))) -eq 0 ]]; then echo 0; else echo 6; fi )"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "bumpalo"
@@ -25,15 +25,15 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "getrandom"
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "log"
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -147,15 +147,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -170,9 +170,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "atomic",
  "getrandom",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b682e8c381995ea03130e381928e0e005b7c9eb483c6c8682f50e07b33c2b7"
+checksum = "22b7ad00068276db5fea436dba78daa7891b8d60db76e4f51cbdefbdecdab97e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,22 +177,7 @@ mod test_ordering {
 
 impl OrdUuid {
     fn as_u128(&self) -> u128 {
-        ((self.0[0] as u128) << 120)
-            | ((self.0[1] as u128) << 112)
-            | ((self.0[2] as u128) << 104)
-            | ((self.0[3] as u128) << 96)
-            | ((self.0[4] as u128) << 88)
-            | ((self.0[5] as u128) << 80)
-            | ((self.0[6] as u128) << 72)
-            | ((self.0[7] as u128) << 64)
-            | ((self.0[8] as u128) << 56)
-            | ((self.0[9] as u128) << 48)
-            | ((self.0[10] as u128) << 40)
-            | ((self.0[11] as u128) << 32)
-            | ((self.0[12] as u128) << 24)
-            | ((self.0[13] as u128) << 16)
-            | ((self.0[14] as u128) << 8)
-            | self.0[15] as u128
+        u128::from_be_bytes(self.0)
     }
 
     pub fn as_bytes(&self) -> [u8; NUM_BYTES] {
@@ -489,24 +474,7 @@ mod test_order_bits_lexically_for_ord_v {
 }
 
 fn u128_to_bytes(v: u128) -> [u8; NUM_BYTES] {
-    [
-        (v >> 120) as u8,
-        (v >> 112) as u8,
-        (v >> 104) as u8,
-        (v >> 96) as u8,
-        (v >> 88) as u8,
-        (v >> 80) as u8,
-        (v >> 72) as u8,
-        (v >> 64) as u8,
-        (v >> 56) as u8,
-        (v >> 48) as u8,
-        (v >> 40) as u8,
-        (v >> 32) as u8,
-        (v >> 24) as u8,
-        (v >> 16) as u8,
-        (v >> 8) as u8,
-        v as u8,
-    ]
+    v.to_be_bytes()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Includes the changes present in https://github.com/josephcopenhaver/ord-uuid-rs/pull/22

Also resolves https://github.com/josephcopenhaver/ord-uuid-rs/security/code-scanning/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified internal UUID conversion logic with no change to behavior or public API.
- Tests
  - Updated tests to match the internal implementation; outcomes unchanged.
- Chores
  - Hardened CI workflow by restricting test job permissions to read-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->